### PR TITLE
Fix overrides

### DIFF
--- a/NetCoreWebDriverFactoryDevelopment.sln
+++ b/NetCoreWebDriverFactoryDevelopment.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlexanderOnTest.NetCoreWebD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlexanderOnTest.WebDriverFactoryNunitConfig", "src\Main\AlexanderOnTest.WebDriverFactoryNunitConfig\AlexanderOnTest.WebDriverFactoryNunitConfig.csproj", "{844BA98B-6BD2-4A93-8C09-29D876228809}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebDriverFactoryNunitConfigUnitTests", "src\Test\WebDriverFactoryNunitConfigUnitTests\WebDriverFactoryNunitConfigUnitTests.csproj", "{AA29850D-335F-4C3A-9982-D7D5357D2F7D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,10 @@ Global
 		{844BA98B-6BD2-4A93-8C09-29D876228809}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{844BA98B-6BD2-4A93-8C09-29D876228809}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{844BA98B-6BD2-4A93-8C09-29D876228809}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA29850D-335F-4C3A-9982-D7D5357D2F7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA29850D-335F-4C3A-9982-D7D5357D2F7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA29850D-335F-4C3A-9982-D7D5357D2F7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA29850D-335F-4C3A-9982-D7D5357D2F7D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -42,6 +48,7 @@ Global
 		{3F97382B-6E44-422D-8EC0-A54968A60531} = {11555F43-5282-451E-99CC-3D16D391C790}
 		{6112DF9A-69C8-47C0-B362-B3F5DAAC11D9} = {8A7C80EE-4A21-466B-8519-EBCED9CF00D7}
 		{844BA98B-6BD2-4A93-8C09-29D876228809} = {11555F43-5282-451E-99CC-3D16D391C790}
+		{AA29850D-335F-4C3A-9982-D7D5357D2F7D} = {8A7C80EE-4A21-466B-8519-EBCED9CF00D7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1F82661E-6641-4817-BCA2-1644BBDB32DD}

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.csproj
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.1-alpha1</Version>
+    <Version>4.1.0</Version>
     <Company>AlexanderOnTest.tech</Company>
     <Authors>Alexander Oliveira Dunn</Authors>
     <Product>NetCoreWebDriverFactory</Product>
@@ -31,8 +31,9 @@ contains test projects for Windows, Linux and MacOS. These can be used to test y
 The supporting package https://www.nuget.org/packages/Selenium.WebDriver.WebDriverFactoryNunitConfig provides easy test configuration options if using Nunit 3 for your tests.</Description>
 
     <PackageReleaseNotes>
-        v4.0.1
+        v4.1.0
         Added Mutability to the WebDriverConfiguration implementation
+        Correctly use the GridUri passed in in an IWebDriverConfiguration over the factory default
         v4.0.0
         Added support for:
         Selenium Webdriver v4.x and Grid 4.x
@@ -49,9 +50,9 @@ The supporting package https://www.nuget.org/packages/Selenium.WebDriver.WebDriv
     <PackageTags>Selenium, WebDriverFactory, WebDriver, Selenium WebDriver, DotNet Core, .net Core, .net Framework, .net 6</PackageTags>
     <PackageId>Selenium.WebDriver.NetCoreWebDriverFactory</PackageId>
     <LangVersion>default</LangVersion>
-    <AssemblyVersion>4.0.1</AssemblyVersion>
-    <FileVersion>4.0.1</FileVersion>
-    <PackageVersion>4.0.1-alpha1</PackageVersion>
+    <AssemblyVersion>4.1.0</AssemblyVersion>
+    <FileVersion>4.1.0</FileVersion>
+    <PackageVersion>4.1.0</PackageVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/AlexanderOnTest/NetCoreWebDriverFactory.git</RepositoryUrl>

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.csproj
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.0</Version>
+    <Version>4.0.1-alpha1</Version>
     <Company>AlexanderOnTest.tech</Company>
     <Authors>Alexander Oliveira Dunn</Authors>
     <Product>NetCoreWebDriverFactory</Product>
@@ -30,12 +30,15 @@ contains test projects for Windows, Linux and MacOS. These can be used to test y
 
 The supporting package https://www.nuget.org/packages/Selenium.WebDriver.WebDriverFactoryNunitConfig provides easy test configuration options if using Nunit 3 for your tests.</Description>
 
-    <PackageReleaseNotes>v4.0.0
-Added support for:
-Selenium Webdriver v4.x and Grid 4.x
-Chromium Edge on Windows, Linux and MacOs
-Internet Explorer Mode testing in Edge on Local Windows
-Requesting a browser with a given language culture where supported    
+    <PackageReleaseNotes>
+        v4.0.1
+        Added Mutability to the WebDriverConfiguration implementation
+        v4.0.0
+        Added support for:
+        Selenium Webdriver v4.x and Grid 4.x
+        Chromium Edge on Windows, Linux and MacOs
+        Internet Explorer Mode testing in Edge on Local Windows
+        Requesting a browser with a given language culture where supported
     </PackageReleaseNotes>
 
     <Copyright>Copyright 2022 Alexander Oliveira Dunn</Copyright>
@@ -46,9 +49,9 @@ Requesting a browser with a given language culture where supported
     <PackageTags>Selenium, WebDriverFactory, WebDriver, Selenium WebDriver, DotNet Core, .net Core, .net Framework, .net 6</PackageTags>
     <PackageId>Selenium.WebDriver.NetCoreWebDriverFactory</PackageId>
     <LangVersion>default</LangVersion>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
-    <PackageVersion>4.0.0</PackageVersion>
+    <AssemblyVersion>4.0.1</AssemblyVersion>
+    <FileVersion>4.0.1</FileVersion>
+    <PackageVersion>4.0.1-alpha1</PackageVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/AlexanderOnTest/NetCoreWebDriverFactory.git</RepositoryUrl>

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.xml
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.xml
@@ -929,13 +929,14 @@
         <member name="P:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GridUri">
             <inheritdoc />
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GetWebDriver(OpenQA.Selenium.DriverOptions,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Drawing.Size)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GetWebDriver(OpenQA.Selenium.DriverOptions,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Drawing.Size,System.Uri)">
             <summary>
             Return a RemoteWebDriver of the given browser type with default settings.
             </summary>
             <param name="options"></param>
             <param name="windowSize"></param>
             <param name="windowCustomSize"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Config.IWebDriverConfiguration)">
@@ -945,7 +946,7 @@
             <param name="configuration"></param>
             <returns></returns>
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,OpenQA.Selenium.PlatformType,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,OpenQA.Selenium.PlatformType,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo,System.Uri)">
             <summary>
             Return a configured RemoteWebDriver of the given browser type with default settings.
             </summary>
@@ -955,6 +956,7 @@
             <param name="headless"></param>
             <param name="windowCustomSize"></param>
             <param name="requestedCulture"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultRemoteWebDriverFactory.Dispose(System.Boolean)">
@@ -990,7 +992,7 @@
             The LocalWebDriverFactory instance to use.
             </summary>
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,OpenQA.Selenium.PlatformType,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,OpenQA.Selenium.PlatformType,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo,System.Uri)">
             <summary>
             Return a WebDriver instance of the given configuration.
             </summary>
@@ -1001,6 +1003,7 @@
             <param name="headless"></param>
             <param name="windowCustomSize"></param>
             <param name="requestedCulture"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.DefaultWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Config.IWebDriverConfiguration)">
@@ -1099,7 +1102,7 @@
             The Uri of your selenium grid for remote WebDriver instances.
             </summary>
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,OpenQA.Selenium.PlatformType,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,OpenQA.Selenium.PlatformType,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo,System.Uri)">
             <summary>
             Return a configured RemoteWebDriver of the given browser type with default settings.
             </summary>
@@ -1109,6 +1112,7 @@
             <param name="headless"></param>
             <param name="windowCustomSize"></param>
             <param name="requestedCulture"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IRemoteWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Config.IWebDriverConfiguration)">
@@ -1118,13 +1122,14 @@
             <param name="configuration"></param>
             <returns></returns>
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IRemoteWebDriverFactory.GetWebDriver(OpenQA.Selenium.DriverOptions,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Drawing.Size)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IRemoteWebDriverFactory.GetWebDriver(OpenQA.Selenium.DriverOptions,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Drawing.Size,System.Uri)">
             <summary>
             Return a RemoteWebDriver of the given windows size.
             </summary>
             <param name="options"></param>
             <param name="windowSize"></param>
             <param name="windowCustomSize"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="T:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IWebDriverFactory">
@@ -1132,7 +1137,7 @@
             Interface for WebDriverFactory Instances.
             </summary>
         </member>
-        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,OpenQA.Selenium.PlatformType,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo)">
+        <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Browser,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Boolean,OpenQA.Selenium.PlatformType,System.Boolean,System.Drawing.Size,System.Globalization.CultureInfo,System.Uri)">
             <summary>
             Return a WebDriver instance of the given configuration.
             </summary>
@@ -1143,6 +1148,7 @@
             <param name="headless"></param>
             <param name="windowCustomSize"></param>
             <param name="requestedCultrue"></param>
+            <param name="gridUri"></param>
             <returns></returns>
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory.IWebDriverFactory.GetWebDriver(AlexanderOnTest.NetCoreWebDriverFactory.Config.IWebDriverConfiguration)">

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.xml
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/AlexanderOnTest.NetCoreWebDriverFactory.xml
@@ -166,7 +166,7 @@
         </member>
         <member name="M:AlexanderOnTest.NetCoreWebDriverFactory.Config.WebDriverConfiguration.#ctor(AlexanderOnTest.NetCoreWebDriverFactory.Browser,System.Uri,System.Boolean,System.Boolean,OpenQA.Selenium.PlatformType,AlexanderOnTest.NetCoreWebDriverFactory.WindowSize,System.Drawing.Size,System.Globalization.CultureInfo)">
             <summary>
-            Generate a new immutable WebDriverConfiguration instance.
+            Generate a new partially mutable WebDriverConfiguration instance to support overrides.
             </summary>
             <param name="browser"></param>
             <param name="gridUri"></param>

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Config/WebDriverConfiguration.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Config/WebDriverConfiguration.cs
@@ -31,11 +31,10 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
     /// </summary>
     public class WebDriverConfiguration :IWebDriverConfiguration
     {
-        private static readonly SizeJsonConverter SizeJsonConverter = new SizeJsonConverter();
-        private readonly string description;
+        private static readonly SizeJsonConverter SizeJsonConverter = new ();
 
         /// <summary>
-        /// Generate a new immutable WebDriverConfiguration instance.
+        /// Generate a new partially mutable WebDriverConfiguration instance to support overrides.
         /// </summary>
         /// <param name="browser"></param>
         /// <param name="gridUri"></param>
@@ -69,17 +68,6 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
                 ? windowDefinedSize
                 : windowSize.Size();
             LanguageCulture = languageCulture;
-            description = new StringBuilder()
-                .Append($"{base.ToString()}: (")
-                .Append($"Browser: {Browser.ToString()} ")
-                .Append(Headless ? "headless" : "on screen")
-                .Append(windowSize == WindowSize.Defined ? 
-                $", Size: {WindowDefinedSize.Width} x {WindowDefinedSize.Height}, " :
-                $", {windowSize}, ")
-                .Append(IsLocal ? "running locally" : $"running remotely on {GridUri} on platform: {PlatformType}")
-                .Append(languageCulture != null ? $", Requested language culture: {languageCulture}" : "")
-                .Append(")")
-        .ToString();
         }
 
         /// <summary>
@@ -88,7 +76,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
         [DefaultValue(Browser.Firefox)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Browser Browser { get;}
+        public Browser Browser { get; }
 
         /// <summary>
         /// Platform to request for a RemoteWebDriver
@@ -96,7 +84,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
         [DefaultValue(PlatformType.Any)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public PlatformType PlatformType { get;}
+        public PlatformType PlatformType { get; set; }
 
         /// <summary>
         /// WindowSize to request
@@ -104,7 +92,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
         [DefaultValue(WindowSize.Hd)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public WindowSize WindowSize { get;}
+        public WindowSize WindowSize { get; }
 
         /// <summary>
         /// Actual window size requested (if not Maximize/Maximise or Unchanged)
@@ -117,21 +105,21 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
         /// </summary>
         [DefaultValue("http://localhost:4444")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public Uri GridUri { get;}
+        public Uri GridUri { get; set; }
 
         /// <summary>
         /// Use a local WebDriver.
         /// </summary>
         [DefaultValue(true)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool IsLocal { get;}
+        public bool IsLocal { get; set; }
 
         /// <summary>
         /// Run headless if available.
         /// </summary>
         [DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool Headless { get; }
+        public bool Headless { get; set; }
         
         /// <summary>
         /// Request a specific language culture
@@ -145,7 +133,17 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
         /// <returns></returns>
         public override string ToString()
         {
-            return description;
+            return new StringBuilder()
+                .Append($"{base.ToString()}: (")
+                .Append($"Browser: {Browser.ToString()} ")
+                .Append(Headless ? "headless" : "on screen")
+                .Append(WindowSize == WindowSize.Defined ? 
+                    $", Size: {WindowDefinedSize.Width} x {WindowDefinedSize.Height}, " :
+                    $", {WindowSize}, ")
+                .Append(IsLocal ? "running locally" : $"running remotely on {GridUri} on platform: {PlatformType}")
+                .Append(LanguageCulture != null ? $", Requested language culture: {LanguageCulture}" : "")
+                .Append(")")
+                .ToString();;
         }
 
         /// <summary>

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Config/WebDriverConfiguration.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Config/WebDriverConfiguration.cs
@@ -143,7 +143,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Config
                 .Append(IsLocal ? "running locally" : $"running remotely on {GridUri} on platform: {PlatformType}")
                 .Append(LanguageCulture != null ? $", Requested language culture: {LanguageCulture}" : "")
                 .Append(")")
-                .ToString();;
+                .ToString();
         }
 
         /// <summary>

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Utils/Builders/WebDriverConfigurationBuilder.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/Utils/Builders/WebDriverConfigurationBuilder.cs
@@ -52,7 +52,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.Utils.Builders
         private WebDriverConfigurationBuilder()
         {
             browser = Browser.Firefox;
-            platformType = PlatformType.Windows;
+            platformType = PlatformType.Any;
             windowSize = WindowSize.Hd;
             windowDefinedSize = Size.Empty;
             gridUri = new Uri("http://localhost:4444");

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/DefaultRemoteWebDriverFactory.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/DefaultRemoteWebDriverFactory.cs
@@ -74,20 +74,22 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
 
         /// <inheritdoc />
         public Uri GridUri { get; set; }
-        
+
         /// <summary>
         /// Return a RemoteWebDriver of the given browser type with default settings.
         /// </summary>
         /// <param name="options"></param>
         /// <param name="windowSize"></param>
         /// <param name="windowCustomSize"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
         public IWebDriver GetWebDriver(
             DriverOptions options,
             WindowSize windowSize = WindowSize.Hd,
-            Size windowCustomSize = new Size())
+            Size windowCustomSize = new(), 
+            Uri gridUri = null)
         {
-            IWebDriver driver = new RemoteWebDriver(GridUri, options);
+            IWebDriver driver = new RemoteWebDriver(gridUri ?? GridUri, options);
             return webDriverReSizer.SetWindowSize(driver, windowSize, windowCustomSize);
         }
 
@@ -111,7 +113,8 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
                 configuration.WindowSize,
                 configuration.Headless,
                 configuration.WindowDefinedSize,
-                configuration.LanguageCulture
+                configuration.LanguageCulture,
+                configuration.GridUri ?? GridUri
             );
         }
 
@@ -124,14 +127,16 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
         /// <param name="headless"></param>
         /// <param name="windowCustomSize"></param>
         /// <param name="requestedCulture"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
         public IWebDriver GetWebDriver(
-            Browser browser, 
-            PlatformType platformType = PlatformType.Any, 
-            WindowSize windowSize = WindowSize.Hd, 
-            bool headless = false, 
-            Size windowCustomSize = new Size(),
-            CultureInfo requestedCulture = null)
+            Browser browser,
+            PlatformType platformType = PlatformType.Any,
+            WindowSize windowSize = WindowSize.Hd,
+            bool headless = false,
+            Size windowCustomSize = new(),
+            CultureInfo requestedCulture = null, 
+            Uri gridUri = null)
         {
             if (browser == Browser.Safari && platformType != PlatformType.Mac ||
                 browser == Browser.InternetExplorer && platformType != PlatformType.Windows)
@@ -158,19 +163,39 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
             switch (browser)
             {
                 case Browser.Firefox:
-                    return GetWebDriver(DriverOptionsFactory.GetRemoteDriverOptions<FirefoxOptions>(platformType, headless, requestedCulture), windowSize, windowCustomSize);
+                    return GetWebDriver(
+                        DriverOptionsFactory.GetRemoteDriverOptions<FirefoxOptions>(platformType, headless, requestedCulture), 
+                        windowSize, 
+                        windowCustomSize,
+                        gridUri ?? GridUri);
 
                 case Browser.Chrome:
-                    return GetWebDriver(DriverOptionsFactory.GetRemoteDriverOptions<ChromeOptions>(platformType, headless, requestedCulture), windowSize, windowCustomSize);
+                    return GetWebDriver(
+                        DriverOptionsFactory.GetRemoteDriverOptions<ChromeOptions>(platformType, headless, requestedCulture), 
+                        windowSize, 
+                        windowCustomSize,
+                        gridUri ?? GridUri);
 
                 case Browser.InternetExplorer:
-                    return GetWebDriver(DriverOptionsFactory.GetRemoteDriverOptions<InternetExplorerOptions>(platformType, headless), windowSize, windowCustomSize);
+                    return GetWebDriver(
+                        DriverOptionsFactory.GetRemoteDriverOptions<InternetExplorerOptions>(platformType, headless), 
+                        windowSize, 
+                        windowCustomSize,
+                        gridUri ?? GridUri);
 
                 case Browser.Edge:
-                    return GetWebDriver(DriverOptionsFactory.GetRemoteDriverOptions<EdgeOptions>(platformType, headless, requestedCulture), windowSize, windowCustomSize);
+                    return GetWebDriver(
+                        DriverOptionsFactory.GetRemoteDriverOptions<EdgeOptions>(platformType, headless, requestedCulture), 
+                        windowSize, 
+                        windowCustomSize,
+                        gridUri ?? GridUri);
 
                 case Browser.Safari:
-                    return GetWebDriver(DriverOptionsFactory.GetRemoteDriverOptions<SafariOptions>(platformType, headless), windowSize, windowCustomSize);
+                    return GetWebDriver(
+                        DriverOptionsFactory.GetRemoteDriverOptions<SafariOptions>(platformType, headless), 
+                        windowSize, 
+                        windowCustomSize,
+                        gridUri ?? GridUri);
 
                 default:
                     Exception ex = new NotSupportedException($"{browser} is not currently supported.");

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/DefaultWebDriverFactory.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/DefaultWebDriverFactory.cs
@@ -65,15 +65,15 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
         /// <param name="headless"></param>
         /// <param name="windowCustomSize"></param>
         /// <param name="requestedCulture"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
-        public IWebDriver GetWebDriver(
-            Browser browser, 
-            WindowSize windowSize = WindowSize.Hd, 
+        public IWebDriver GetWebDriver(Browser browser,
+            WindowSize windowSize = WindowSize.Hd,
             bool isLocal = true,
-            PlatformType platformType = PlatformType.Any, 
-            bool headless = false, 
+            PlatformType platformType = PlatformType.Any,
+            bool headless = false,
             Size windowCustomSize = new Size(),
-            CultureInfo requestedCulture = null)
+            CultureInfo requestedCulture = null, Uri gridUri = null)
         {
             string configurationDescription = new StringBuilder()
                 .Append($"Browser: {browser.ToString()}")

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/IRemoteWebDriverFactory.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/IRemoteWebDriverFactory.cs
@@ -45,14 +45,15 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
         /// <param name="headless"></param>
         /// <param name="windowCustomSize"></param>
         /// <param name="requestedCulture"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
-        IWebDriver GetWebDriver(
-            Browser browser, 
-            PlatformType platformType = PlatformType.Any, 
-            WindowSize windowSize = WindowSize.Hd, 
-            bool headless = false, 
+        IWebDriver GetWebDriver(Browser browser,
+            PlatformType platformType = PlatformType.Any,
+            WindowSize windowSize = WindowSize.Hd,
+            bool headless = false,
             Size windowCustomSize = new Size(),
-            CultureInfo requestedCulture = null);
+            CultureInfo requestedCulture = null, 
+            Uri gridUri = null);
 
         /// <summary>
         /// Return a RemoteWebDriver instance of the given configuration.
@@ -67,7 +68,12 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
         /// <param name="options"></param>
         /// <param name="windowSize"></param>
         /// <param name="windowCustomSize"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
-        IWebDriver GetWebDriver(DriverOptions options, WindowSize windowSize = WindowSize.Hd, Size windowCustomSize = new Size());
+        IWebDriver GetWebDriver(
+            DriverOptions options,
+            WindowSize windowSize = WindowSize.Hd,
+            Size windowCustomSize = new Size(), 
+            Uri gridUri = null);
     }
 }

--- a/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/IWebDriverFactory.cs
+++ b/src/Main/AlexanderOnTest.NetCoreWebDriverFactory/WebDriverFactory/IWebDriverFactory.cs
@@ -37,15 +37,16 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.WebDriverFactory
         /// <param name="headless"></param>
         /// <param name="windowCustomSize"></param>
         /// <param name="requestedCultrue"></param>
+        /// <param name="gridUri"></param>
         /// <returns></returns>
-        IWebDriver GetWebDriver(
-            Browser browser, 
-            WindowSize windowSize = WindowSize.Hd, 
+        IWebDriver GetWebDriver(Browser browser,
+            WindowSize windowSize = WindowSize.Hd,
             bool isLocal = true,
-            PlatformType platformType = PlatformType.Any, 
-            bool headless = false, 
+            PlatformType platformType = PlatformType.Any,
+            bool headless = false,
             Size windowCustomSize = new Size(),
-            CultureInfo requestedCultrue = null);
+            CultureInfo requestedCultrue = null, 
+            Uri gridUri = null);
 
         /// <summary>
         /// Return a WebDriver instance of the given configuration.

--- a/src/Main/AlexanderOnTest.WebDriverFactoryNunitConfig/AlexanderOnTest.WebDriverFactoryNunitConfig.csproj
+++ b/src/Main/AlexanderOnTest.WebDriverFactoryNunitConfig/AlexanderOnTest.WebDriverFactoryNunitConfig.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.0-alpha3</Version>
+    <Version>4.1.0</Version>
     <PackageProjectUrl>https://github.com/AlexanderOnTesting/NetCoreWebDriverFactory/wiki/Selenium.WebDriver.WebDriverFactoryNunitConfig</PackageProjectUrl>
     <PackageIcon>AoT.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
@@ -18,7 +18,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <PackageReleaseNotes>
-      v4.0.1
+      v4.1.0
       Fix to ensure GridUri overides prioritise correctly.
       The gridUri value from Config_GridUri.json is applied even when a Config_WebDriver.json is present.
       v4.0.0
@@ -31,11 +31,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Selenium.WebDriver.WebDriverFactoryNunitConfig</PackageId>
     <LangVersion>7.3</LangVersion>
-    <AssemblyVersion>4.0.1</AssemblyVersion>
+    <AssemblyVersion>4.1.0</AssemblyVersion>
     <RepositoryUrl>https://github.com/AlexanderOnTest/NetCoreWebDriverFactory.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>4.0.1-alpha3</PackageVersion>
-    <FileVersion>4.0.1</FileVersion>
+    <PackageVersion>4.1.0</PackageVersion>
+    <FileVersion>4.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,7 +44,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="Selenium.WebDriver.NetCoreWebDriverFactory" Version="4.0.1-alpha1" />
+    <PackageReference Include="Selenium.WebDriver.NetCoreWebDriverFactory" Version="4.1.0" />
     <None Include="AoT.png" Pack="true" PackagePath="">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Main/AlexanderOnTest.WebDriverFactoryNunitConfig/AlexanderOnTest.WebDriverFactoryNunitConfig.csproj
+++ b/src/Main/AlexanderOnTest.WebDriverFactoryNunitConfig/AlexanderOnTest.WebDriverFactoryNunitConfig.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.0</Version>
+    <Version>4.0.0-alpha3</Version>
     <PackageProjectUrl>https://github.com/AlexanderOnTesting/NetCoreWebDriverFactory/wiki/Selenium.WebDriver.WebDriverFactoryNunitConfig</PackageProjectUrl>
     <PackageIcon>AoT.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
@@ -17,21 +17,25 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <PackageReleaseNotes>v4.0.0
-       Support for Selenium v4.x and Selenium Grid v4.x
-       WebDriver Factory now supports Microsoft Edge on Windows, Linux and MacOs
-       Webdriver factory now supports Internet Explorer mode on Microsoft Edge in local mode (required for Windows 11) 
-       Support for requesting a browser with a given language culture where supported. 
+    <PackageReleaseNotes>
+      v4.0.1
+      Fix to ensure GridUri overides prioritise correctly.
+      The gridUri value from Config_GridUri.json is applied even when a Config_WebDriver.json is present.
+      v4.0.0
+      Support for Selenium v4.x and Selenium Grid v4.x
+      WebDriver Factory now supports Microsoft Edge on Windows, Linux and MacOs
+      Webdriver factory now supports Internet Explorer mode on Microsoft Edge in local mode (required for Windows 11)
+      Support for requesting a browser with a given language culture where supported.
     </PackageReleaseNotes>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Selenium.WebDriver.WebDriverFactoryNunitConfig</PackageId>
     <LangVersion>7.3</LangVersion>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1</AssemblyVersion>
     <RepositoryUrl>https://github.com/AlexanderOnTest/NetCoreWebDriverFactory.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>4.0.0</PackageVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <PackageVersion>4.0.1-alpha3</PackageVersion>
+    <FileVersion>4.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +44,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="Selenium.WebDriver.NetCoreWebDriverFactory" Version="4.0.0" />
+    <PackageReference Include="Selenium.WebDriver.NetCoreWebDriverFactory" Version="4.0.1-alpha1" />
     <None Include="AoT.png" Pack="true" PackagePath="">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="log4net" Version="2.0.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test/AlexanderOnTest.NetCoreWebDriverFactory.Lib.Test.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="log4net" Version="2.0.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="Selenium.WebDriver.WebDriverFactoryNunitConfig" Version="4.0.0" />
+    <PackageReference Include="Selenium.WebDriver.WebDriverFactoryNunitConfig" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.LinuxTests/AlexanderOnTest.NetCoreWebDriverFactory.LinuxTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.LinuxTests/AlexanderOnTest.NetCoreWebDriverFactory.LinuxTests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.Support" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="101.0.4951.4100" />
-    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0" />
+    <PackageReference Include="Selenium.Support" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6102" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.MacOsTests/AlexanderOnTest.NetCoreWebDriverFactory.MacOsTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.MacOsTests/AlexanderOnTest.NetCoreWebDriverFactory.MacOsTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.Support" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="101.0.4951.4100" />
-    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="101.0.1210.9-pre" />
+    <PackageReference Include="Selenium.Support" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6102" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0.1" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="101.0.1210.47" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6100" />
-    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.0.0.1" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6102" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0.1" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.csproj
@@ -21,14 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="log4net" Version="2.0.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="98.0.4758.8000" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6100" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.31.0" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.0.0.1" />
   </ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DependencyInjection/DriverPathTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DependencyInjection/DriverPathTests.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DependencyInjection
 {
+    [Category("CI")]
     public class DriverPathTests
     {
         private static readonly DriverPath ExpectedDriverPath = 

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/FakeWebDriver.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/FakeWebDriver.cs
@@ -24,7 +24,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverManager
     internal class FakeWebDriver : IWebDriver
 #pragma warning restore S3881 // "IDisposable" should be implemented correctly
     {
-        private bool isQuit = false;
+        private bool isQuit;
 
         public IWebElement FindElement(By @by)
         {

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/FakeWebDriverFactory.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/FakeWebDriverFactory.cs
@@ -28,14 +28,13 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverManager
     {
         private static readonly ILog Logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public IWebDriver GetWebDriver(
-            Browser browser, 
-            WindowSize windowSize = WindowSize.Hd, 
+        public IWebDriver GetWebDriver(Browser browser,
+            WindowSize windowSize = WindowSize.Hd,
             bool isLocal = true,
-            PlatformType platformType = PlatformType.Any, 
-            bool headless = false, 
+            PlatformType platformType = PlatformType.Any,
+            bool headless = false,
             Size windowCustomSize = new Size(),
-            CultureInfo requestedCulture = null)
+            CultureInfo requestedCulture = null, Uri gridUri = null)
         {
             Logger.Info($"Fake WebDriver requested.");
             return new FakeWebDriver();

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/Tests/ConverterTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverManager/Tests/ConverterTests.cs
@@ -55,7 +55,6 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverManager.Tests
             //Assert
             using (new AssertionScope())
             {
-                actualJson.Should().Contain("\"PlatformType\":\"Windows\"");
                 actualJson.Should().Contain($"\"WindowSize\":\"Defined\"");
                 actualJson.Should().Contain($"\"WindowDefinedSize\":{{\"width\":{expectedWidth},\"height\":{expectedHeight}}}");
                 actualJson.Should().Contain("\"GridUri\":\"http://localhost:4444\"");
@@ -76,7 +75,6 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverManager.Tests
             //Assert
             using (new AssertionScope())
             {
-                actualJson.Should().Contain("\"PlatformType\":\"Windows\"");
                 actualJson.Should().Contain($"\"WindowSize\":\"{windowSize}\"");
                 actualJson.Should().Contain("\"WindowDefinedSize\":{\"width\":0,\"height\":0}");
                 actualJson.Should().Contain("\"GridUri\":\"http://localhost:4444\"");
@@ -98,7 +96,6 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverManager.Tests
             //Assert
             using (new AssertionScope())
             {
-                actualJson.Should().Contain("\"PlatformType\":\"Windows\"");
                 actualJson.Should().Contain("\"WindowSize\":\"Defined\"");
                 actualJson.Should().Contain($"\"WindowDefinedSize\":{{\"width\":{width},\"height\":{height}}}");
                 actualJson.Should().Contain("\"GridUri\":\"http://localhost:4444\"");

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsCultureTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsCultureTests.cs
@@ -33,6 +33,7 @@ using static AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFact
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFactory;
 
+[Category("CI")]
 public class LocalDriverOptionsCultureTests
 {
     private IDriverOptionsFactory optionsFactory;

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsFactoryTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsFactoryTests.cs
@@ -131,7 +131,7 @@ public class LocalDriverOptionsFactoryTests
             List<object> arguments = argumentObject as List<object>;
             if (arguments != null)
             {
-                argumentStringsList = arguments?.Select(obj => obj as string).ToList();
+                argumentStringsList = arguments.Select(obj => obj as string).ToList();
             }
         }
         

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsFactoryTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/LocalDriverOptionsFactoryTests.cs
@@ -31,6 +31,7 @@ using OpenQA.Selenium.Safari;
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFactory;
 
+[Category("CI")]
 public class LocalDriverOptionsFactoryTests
 {
     private IDriverOptionsFactory optionsFactory;

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/RemoteDriverOptionsCultureTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/RemoteDriverOptionsCultureTests.cs
@@ -34,6 +34,7 @@ using static AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFact
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFactory;
 
+[Category("CI")]
 public class RemoteDriverOptionsCultureTests
 {
     private IDriverOptionsFactory optionsFactory;

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/RemoteDriverOptionsFactoryTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/RemoteDriverOptionsFactoryTests.cs
@@ -31,6 +31,7 @@ using OpenQA.Selenium.Safari;
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFactory;
 
+[Category("CI")]
 public class RemoteDriverOptionsFactoryTests
 {
     private IDriverOptionsFactory optionsFactory;

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/StaticDriverOptionsFactoryCultureTests.cs
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.UnitTests/DriverOptionsFactory/StaticDriverOptionsFactoryCultureTests.cs
@@ -28,6 +28,7 @@ using static FluentAssertions.FluentActions;
 
 namespace AlexanderOnTest.NetCoreWebDriverFactory.UnitTests.DriverOptionsFactory
 {
+    [Category("CI")]
     public class StaticDriverOptionsFactoryCultureTests
     {
         internal const string UnsupportedBrowserMessage =

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.Support" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="101.0.4951.4100" />
+    <PackageReference Include="Selenium.Support" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6100" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64" Version="0.31.0" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.0.0.1" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="101.0.1210.9-pre" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="101.0.1210.47" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests.csproj
+++ b/src/Test/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests/AlexanderOnTest.NetCoreWebDriverFactory.WindowsTests.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Selenium.Support" Version="4.2.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6100" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="102.0.5005.6102" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64" Version="0.31.0" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.0.0.1" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.2.0" />
     <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="101.0.1210.47" />
   </ItemGroup>
 

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions">
-      <Version>6.6.0</Version>
+      <Version>6.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>
@@ -106,7 +106,7 @@
       <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.ChromeDriver">
-      <Version>102.0.5005.6100</Version>
+      <Version>102.0.5005.6102</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64">
       <Version>0.31.0</Version>

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
@@ -103,10 +103,10 @@
       <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver">
-      <Version>4.1.1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.ChromeDriver">
-      <Version>101.0.4951.4100</Version>
+      <Version>102.0.5005.6100</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.GeckoDriver.Win64">
       <Version>0.31.0</Version>

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests.csproj
@@ -94,7 +94,7 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.13.3</Version>
+      <Version>3.13.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit.Extension.VSProjectLoader">
       <Version>3.9.0</Version>
@@ -112,13 +112,13 @@
       <Version>0.31.0</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.IEDriver">
-      <Version>4.0.0.1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.MSEdgeDriver">
-      <Version>101.0.1210.9-pre</Version>
+      <Version>101.0.1210.47</Version>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver.WebDriverFactoryNunitConfig">
-      <Version>4.0.0</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.AppContext">
       <Version>4.3.0</Version>

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/ConfigurationBasedTests.cs
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/ConfigurationBasedTests.cs
@@ -43,7 +43,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.Local)]
-        public new void LocalWebDriverFactoryWorks(
+        public void LocalWebDriverFactoryWorks(
             Browser browser, 
             BrowserVisibility browserVisibility, 
             BrowserCulture browserCulture = BrowserCulture.Undefined)
@@ -62,7 +62,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteLinux)]
-        public new void RemoteWebDriverFactoryWorksForLinux(
+        public void RemoteWebDriverFactoryWorksForLinux(
             Browser browser,
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)
@@ -86,7 +86,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteMacOs)]
-        public new void RemoteWebDriverFactoryWorksForMacOs(
+        public void RemoteWebDriverFactoryWorksForMacOs(
             Browser browser, 
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)
@@ -110,7 +110,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteWindows)]
-        public new void RemoteWebDriverFactoryWorksForWindows(
+        public void RemoteWebDriverFactoryWorksForWindows(
             Browser browser, 
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)
@@ -157,7 +157,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Edge, BrowserVisibility.Headless)]
         [TestCase(Browser.InternetExplorer, BrowserVisibility.OnScreen)]
         [Category(TestCategories.NotSupported)]
-        public new void RequestingUnsupportedLocalCulturedBrowserThrowsInformativeException(
+        public void RequestingUnsupportedLocalCulturedBrowserThrowsInformativeException(
             Browser browser, 
             BrowserVisibility browserVisibility)
         {
@@ -195,7 +195,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(PlatformType.Windows, Browser.Edge, BrowserVisibility.Headless)]
         [TestCase(PlatformType.Windows, Browser.InternetExplorer, BrowserVisibility.OnScreen)]
         [Category(TestCategories.NotSupported)]
-        public new void RequestingUnsupportedRemoteCulturedBrowserThrowsInformativeException(
+        public void RequestingUnsupportedRemoteCulturedBrowserThrowsInformativeException(
             PlatformType platformType,
             Browser browser, 
             BrowserVisibility browserVisibility)

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/LocalWebDriverFactoryTests.cs
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/LocalWebDriverFactoryTests.cs
@@ -40,7 +40,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Edge, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
-        public new void LocalWebDriverFactoryWorks(
+        public void LocalWebDriverFactoryWorks(
             Browser browser, 
             BrowserVisibility browserVisibility, 
             BrowserCulture browserCulture = BrowserCulture.Undefined)

--- a/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/RemoteWebDriverFactoryTests.cs
+++ b/src/Test/FrameworkTests/AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests/RemoteWebDriverFactoryTests.cs
@@ -42,7 +42,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteLinux)]
-        public new void RemoteWebDriverFactoryWorksForLinux(
+        public void RemoteWebDriverFactoryWorksForLinux(
             Browser browser,
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)
@@ -66,7 +66,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteMacOs)]
-        public new void RemoteWebDriverFactoryWorksForMacOs(
+        public void RemoteWebDriverFactoryWorksForMacOs(
             Browser browser, 
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)
@@ -90,7 +90,7 @@ namespace AlexanderOnTest.NetCoreWebDriverFactory.FrameworkTests
         [TestCase(Browser.Firefox, BrowserVisibility.OnScreen, BrowserCulture.Spanish)]
         [TestCase(Browser.Firefox, BrowserVisibility.Headless, BrowserCulture.Spanish)]
         [Category(TestCategories.RemoteWindows)]
-        public new void RemoteWebDriverFactoryWorksForWindows(
+        public void RemoteWebDriverFactoryWorksForWindows(
             Browser browser, 
             BrowserVisibility browserVisibility,
             BrowserCulture browserCulture)

--- a/src/Test/WebDriverFactoryNunitConfigUnitTests/ConfigLoadingTests.cs
+++ b/src/Test/WebDriverFactoryNunitConfigUnitTests/ConfigLoadingTests.cs
@@ -1,0 +1,167 @@
+using System.IO;
+using System.Threading.Tasks;
+using AlexanderOnTest.NetCoreWebDriverFactory.Config;
+using AlexanderOnTest.WebDriverFactoryNunitConfig.TestSettings;
+using FluentAssertions;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using static System.Environment;
+
+namespace WebDriverFactoryNunitConfigUnitTests;
+
+[Category("CI")]
+public class ConfigLoadingTests
+{
+    private const string GridUriConfigFileName = "Config_GridUri.json";
+    private const string SampleGridUriConfig = "\"http://from.Config.Grid.Uri:31767\"";
+    private const string InvalidGridUriConfig = "\"http://\"";
+    private const string WebDriverConfigFileName = "Config_WebDriver.json";
+    private const string SampleWebDriverConfig =
+        "{\"Browser\":\"CHROME\",\"IsLocal\":false,\"PlatformType\":\"LINUX\",\"WindowSize\":\"FHd\",\"Headless\":true,\"GridUri\":\"http://from.webdriver.config:30884\",\"LanguageCulture\":\"\"}";
+    private string _previousGridUriConfigFile;
+    private string _previousWebDriverConfigFile;
+
+    [OneTimeSetUp]
+    public async Task GetCurrentConfigs()
+    {
+        _previousGridUriConfigFile = await ReadConfig(GridUriConfigFileName);
+        _previousWebDriverConfigFile = await ReadConfig(WebDriverConfigFileName);
+    }
+    
+    [SetUp]
+    public void Setup()
+    {
+    }
+    
+    [Test]
+    public async Task GridUriReadsFromGridUriConfigWithNoWebDriverConfig()
+    {
+        await WriteConfig(WebDriverConfigFileName, null);
+        await WriteConfig(GridUriConfigFileName, SampleGridUriConfig);
+
+        WebDriverSettings.GridUri.Should().Be("http://from.config.grid.uri:31767/");
+    }
+
+    [Test]
+    public async Task GridUriReadsFromWebDriverConfigIfNoGridUriConfig()
+    {
+        await WriteConfig(WebDriverConfigFileName, SampleWebDriverConfig);
+        await WriteConfig(GridUriConfigFileName, null);
+
+        WebDriverSettings.GridUri.Should().Be("http://from.webdriver.config:30884/");
+    }
+    
+    [Test]
+    public async Task GridUriReadsFromGridUriConfigInsteadOfWebDriverConfig()
+    {
+        await WriteConfig(WebDriverConfigFileName, SampleWebDriverConfig);
+        await WriteConfig(GridUriConfigFileName, SampleGridUriConfig);
+
+        WebDriverSettings.GridUri.Should().Be("http://from.config.grid.uri:31767/");
+    }
+    
+    
+    [Test]
+    public async Task GridUriReturnsLocalhostIfNoConfigs()
+    {
+        await WriteConfig(WebDriverConfigFileName, null);
+        await WriteConfig(GridUriConfigFileName, null);
+
+        WebDriverSettings.GridUri.Should().Be("http://localhost:4444");
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsCorrectGridUriIfNoGridUriConfig()
+    {
+        await WriteConfig(WebDriverConfigFileName, SampleWebDriverConfig);
+        await WriteConfig(GridUriConfigFileName, null);
+
+        WebDriverSettings.OverriddenWebDriverConfiguration.GridUri.Should().Be("http://from.webdriver.config:30884/");
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsGridUriValueFromGridUriConfigIfPresent()
+    {
+        await WriteConfig(WebDriverConfigFileName, SampleWebDriverConfig);
+        await WriteConfig(GridUriConfigFileName, SampleGridUriConfig);
+
+        WebDriverSettings.OverriddenWebDriverConfiguration.GridUri.Should().Be("http://from.config.grid.uri:31767/");
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsLocalhostIfNoConfigsPresent()
+    {
+        await WriteConfig(WebDriverConfigFileName, null);
+        await WriteConfig(GridUriConfigFileName, null);
+
+        WebDriverSettings.OverriddenWebDriverConfiguration.GridUri.Should().Be("http://localhost:4444");
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsExpectedValuesIfNoConfigsPresent()
+    {
+        await WriteConfig(WebDriverConfigFileName, null);
+        await WriteConfig(GridUriConfigFileName, null);
+
+        WebDriverSettings.OverriddenWebDriverConfiguration.Should().BeEquivalentTo(WebDriverSettings.WebDriverConfiguration) ;
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsExpectedValuesIfOnlyGridUriConfigPresent()
+    {
+        await WriteConfig(WebDriverConfigFileName, null);
+        await WriteConfig(GridUriConfigFileName, SampleGridUriConfig);
+
+        var expectedConfig = WebDriverSettings.WebDriverConfiguration as WebDriverConfiguration;
+        expectedConfig.GridUri = new ("http://from.config.grid.uri:31767/");
+        
+        WebDriverSettings.OverriddenWebDriverConfiguration.Should().BeEquivalentTo(expectedConfig) ;
+    }
+
+    [Test]
+    public async Task OverriddenWebDriverConfigReturnsLocalConfigIfInvalidGridUriConfigPresent()
+    {
+        await WriteConfig(WebDriverConfigFileName, SampleWebDriverConfig);
+        await WriteConfig(GridUriConfigFileName, InvalidGridUriConfig);
+
+        var expectedConfig = WebDriverSettings.WebDriverConfiguration as WebDriverConfiguration;
+        expectedConfig.IsLocal = true;
+        expectedConfig.PlatformType = PlatformType.Any;
+        expectedConfig.Headless = false;
+        
+        WebDriverSettings.OverriddenWebDriverConfiguration.Should().BeEquivalentTo(expectedConfig) ;
+    }
+
+    [OneTimeTearDown]
+    public async Task RestorePreviousConfigs()
+    {
+        await WriteConfig(GridUriConfigFileName, _previousGridUriConfigFile);
+        await WriteConfig(WebDriverConfigFileName, _previousWebDriverConfigFile);
+    }
+    
+    private async Task<string> ReadConfig(string configFileName)
+    {
+        string configFilePath = Path.Combine(GetFolderPath(SpecialFolder.MyDocuments), configFileName);
+        if (!string.IsNullOrEmpty(configFilePath) && File.Exists(configFilePath))
+        {
+            using (StreamReader file = File.OpenText(configFilePath))
+            {
+                return file.ReadToEnd();
+            }
+        }
+        return null;
+    }
+    
+    private async Task WriteConfig(string configFileName, string configToWrite)
+    {
+        string configFilePath = Path.Combine(GetFolderPath(SpecialFolder.MyDocuments), configFileName);
+        if (string.IsNullOrEmpty(configToWrite) && File.Exists(configFilePath))
+        {
+            File.Delete(configFilePath);
+        }
+        else
+        {
+            await File.WriteAllTextAsync(configFilePath, configToWrite);
+        }
+    }
+}

--- a/src/Test/WebDriverFactoryNunitConfigUnitTests/ConfigLoadingTests.cs
+++ b/src/Test/WebDriverFactoryNunitConfigUnitTests/ConfigLoadingTests.cs
@@ -152,7 +152,7 @@ public class ConfigLoadingTests
         return null;
     }
     
-    private async Task WriteConfig(string configFileName, string configToWrite)
+    private async Task WriteConfig(string configFileName, string? configToWrite)
     {
         string configFilePath = Path.Combine(GetFolderPath(SpecialFolder.MyDocuments), configFileName);
         if (string.IsNullOrEmpty(configToWrite) && File.Exists(configFilePath))

--- a/src/Test/WebDriverFactoryNunitConfigUnitTests/WebDriverFactoryNunitConfigUnitTests.csproj
+++ b/src/Test/WebDriverFactoryNunitConfigUnitTests/WebDriverFactoryNunitConfigUnitTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Main\AlexanderOnTest.WebDriverFactoryNunitConfig\AlexanderOnTest.WebDriverFactoryNunitConfig.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
v 4.1.0
GridUri Overides working as intended.
WebDriverConfiguration GridUri is respected over RemoteWebDriverFactory value.
NunitConfig
Config_GridUri.json is respected over Config_WebDriver.json value